### PR TITLE
Modified to support configfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN chown -R 1:1 /home/daemon
 ENV HOME=/home/daemon
 USER 1:1
 ENTRYPOINT ["overviewer.py"]
-CMD ["/minecraft/world", "/mcmap"]
+CMD ["--config=/minecraft/overviewer.cfg"]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,23 @@ found [here](http://overviewer.org/).
 ## Usage
 
 This Dockerfile requires two volumes owned by UID:GID 1 ( default ).  One volume must be mounted 
-undert `/minecraft` which contains a world directory for the world that you wish to create a
+under `/minecraft` which contains a world directory for the world that you wish to create a
 map of.  The other is the output directory that will contain the generated map mounted under
 `/mcmap`.
 
-Here is an example:
+You will need a config file in the minecraft server root named `overviewer.cfg` where you can specify
+any processing options. The config file should have at least 2 lines defining the worlds directory
+as well as the output directory. An example overviewer.cfg is:
+
+```
+worlds["survival"] = "/minecraft/world"
+outputdir = "/mcmap"
+```
+
+Here is an example of running Overviewer:
 
 ```bash
-docker run -ti --rm -v /volumes/mcworld:/mcmap -v /volumes/minecraft-family:/minecraft:ro overviewer
+docker run -ti --rm -v /volumes/mc-web-output:/mcmap -v /volumes/minecraft-server-root:/minecraft:ro overviewer
 ```
 
 It is recommended that you mount your minecraft world as `ro` so that you can ensure overviewer does

--- a/overviewer.cfg
+++ b/overviewer.cfg
@@ -1,0 +1,2 @@
+worlds["survival"] = "/minecraft/world"
+outputdir = "/mcmap"


### PR DESCRIPTION
The preferred mode of running Overviewer is with a config file. This lets users put an overviewer.cfg file in the server root folder that contains the configuration options for the render. A minimal config file is attached for reference. Documentation has also been updated to reflect this change. 
