### PR TITLE
Generate POIs if defined in config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ ADD https://s3.amazonaws.com/Minecraft.Download/versions/1.8/1.8.jar /home/daemo
 RUN chown -R 1:1 /home/daemon
 ENV HOME=/home/daemon
 USER 1:1
-ENTRYPOINT ["overviewer.py"]
-CMD ["--config=/minecraft/overviewer.cfg"]
+ENTRYPOINT ["/bin/bash", "-c","overviewer.py --config=/minecraft/overviewer.cfg;overviewer.py --config=/minecraft/overviewer.cfg --genpoi"]


### PR DESCRIPTION
This reruns the overviewer.py again with the --genpoi flag to generate any POIs that you have (players, signs, towns, etc). This process is very quick even as it does not need to process all tiles. Example configs with POIs can be found here:

https://github.com/overviewer/Minecraft-Overviewer/wiki/Config-Examples
